### PR TITLE
Fails to load in rails 3.2 project

### DIFF
--- a/lib/ahoy_email/engine.rb
+++ b/lib/ahoy_email/engine.rb
@@ -2,7 +2,7 @@ module AhoyEmail
   class Engine < ::Rails::Engine
 
     initializer "ahoy_email" do |app|
-      AhoyEmail.secret_token = app.config.try(:secret_key_base) || app.config.try(:secret_token)
+      AhoyEmail.secret_token = app.config.respond_to?(:secret_key_base) ? app.config.secret_key_base : app.config.secret_token
     end
 
   end


### PR DESCRIPTION
I have a current rails 3.2 project that fails to load. The try here seems to be calling the method. It also seems to me that you would never want nil here.

```
rails c
Connecting to database specified by database.yml
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/railties-3.2.18/lib/rails/railtie/configuration.rb:85:in `method_missing': undefined method `secret_key_base' for #<Rails::Application::Configuration:0x007feaaf523f40> (NoMethodError)
    from /Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/activesupport-3.2.18/lib/active_support/core_ext/object/try.rb:36:in `try'
    from /Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/ahoy_email-0.1.4/lib/ahoy_email/engine.rb:5:in `block in <class:Engine>'
    from /Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/railties-3.2.18/lib/rails/initializable.rb:30:in `instance_exec'
```
