### PR TITLE
Change asset helper

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -1,7 +1,5 @@
 module AhoyEmail
   class Processor
-    include ActionView::Helpers::AssetTagHelper
-
     attr_reader :message, :options, :ahoy_message
 
     def initialize(message, options = {})
@@ -62,7 +60,7 @@ module AhoyEmail
               format: "gif"
             )
           )
-        pixel = image_tag(url, size: "1x1", alt: nil)
+        pixel = ActionController::Base.helpers.image_tag(url, size: "1x1", alt: nil)
 
         # try to add before body tag
         if raw_source.match(regex)


### PR DESCRIPTION
Rails 3.2.18
resque_mailer
roadie 
In development and staging we are using an object as our asset_host. I don't think this should matter. 

I am running .deliver! on a mail action.

Error:

```
NameError: undefined local variable or method `config' for #<AhoyEmail::Processor:0x007ff1c1b6e558>
from /Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionpack-3.2.18/lib/action_view/helpers/asset_tag_helper.rb:453:in `asset_paths'
```

I got to googleing around and found https://github.com/carrierwaveuploader/carrierwave/pull/5which leads me to https://github.com/carrierwaveuploader/carrierwave/commit/2adf9a585acdcddc9378dd6bd00b1e42a4b14923 

Seems to work when I edit my gem file. 

Full trace:

```
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionpack-3.2.18/lib/action_view/helpers/asset_tag_helper.rb:453:in `asset_paths'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionpack-3.2.18/lib/action_view/helpers/asset_tag_helper.rb:275:in `image_path'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionpack-3.2.18/lib/action_view/helpers/asset_tag_helper.rb:359:in `image_tag'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/ahoy_email-0.1.5/lib/ahoy_email/processor.rb:68:in `track_open'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/ahoy_email-0.1.5/lib/ahoy_email/processor.rb:22:in `process'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/ahoy_email-0.1.5/lib/ahoy_email/mailer.rb:32:in `mail_with_ahoy'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/roadie-2.4.3/lib/roadie/action_mailer_extensions.rb:35:in `mail_with_inline_styles'
/Users/becker/tinyhr/project/app/mailers/receiver_mailer.rb:71:in `survey'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionpack-3.2.18/lib/abstract_controller/base.rb:167:in `process_action'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionpack-3.2.18/lib/abstract_controller/base.rb:121:in `process'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionpack-3.2.18/lib/abstract_controller/rendering.rb:45:in `process'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionmailer-3.2.18/lib/action_mailer/base.rb:459:in `process'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/actionmailer-3.2.18/lib/action_mailer/base.rb:453:in `initialize'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/bundler/gems/resque_mailer-8922b66d7a50/lib/resque_mailer.rb:110:in `new'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/bundler/gems/resque_mailer-8922b66d7a50/lib/resque_mailer.rb:110:in `actual_message'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/bundler/gems/resque_mailer-8922b66d7a50/lib/resque_mailer.rb:150:in `deliver!'
/Users/becker/tinyhr/project/lib/tp/extensions/resque_mailer.rb:27:in `deliver!'
(pry):3:in `__pry__'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:328:in `eval'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:328:in `evaluate_ruby'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:278:in `re'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:254:in `rep'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:234:in `block (3 levels) in repl'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:232:in `loop'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:232:in `block (2 levels) in repl'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:231:in `catch'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:231:in `block in repl'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:230:in `catch'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_instance.rb:230:in `repl'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/pry-0.9.12/lib/pry/pry_class.rb:170:in `start'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/railties-3.2.18/lib/rails/commands/console.rb:47:in `start'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/railties-3.2.18/lib/rails/commands/console.rb:8:in `start'
/Users/becker/.rvm/gems/ruby-1.9.3-p484@project/gems/railties-3.2.18/lib/rails/commands.rb:41:in `<top (required)>'
script/rails:6:in `require'
script/rails:6:in `<main>'
```
