### PR TITLE
Add options hash to message model

### DIFF
--- a/app/models/ahoy/message.rb
+++ b/app/models/ahoy/message.rb
@@ -3,5 +3,11 @@ module Ahoy
     self.table_name = "ahoy_messages"
 
     belongs_to :user, polymorphic: true
+
+    attr_reader :options
+
+    def initialize(options = {})
+      @options = options
+    end
   end
 end

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -11,7 +11,7 @@ module AhoyEmail
 
     def process
       if options[:message]
-        @ahoy_message = AhoyEmail.message_model.new
+        @ahoy_message = AhoyEmail.message_model.new(options)
         ahoy_message.token = generate_token
         ahoy_message.to = message.to.join(", ") if ahoy_message.respond_to?(:to=)
         ahoy_message.user = options[:user]


### PR DESCRIPTION
This should allow passing of other options forward to the Message model
where it can be used.

I would like to track more then one thing per message. For example my store has users and cat clocks. I would like to know the open rate for a user (via the user option currently) and the open rate for my Hello Kitty Kit-Cat clocks. I am thinking I could pass an option of tracking: [clock1, clock2] and I would make my own Message class that would intercept the tracking option. After creation of a message it would insert some records in to a join table. 

If there is a different/better way to tracking many things per message please let me know.
Thanks! 
