### PR TITLE
Add serialized `data` attribute to Ahoy::Message model

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Use `track click: false` to skip tracking, or skip specific links with:
 <a data-skip-click="true" href="...">Can't touch this</a>
 ```
 
+### Abitrary data
+
+You can store arbitrary attributes on the `Ahoy::Message` model in the `data` column.
+
+```
+track data: { notification_id: 2 }
+```
+
 ### UTM Parameters
 
 UTM parameters are added to links if they don’t already exist.
@@ -124,6 +132,7 @@ Skip tracking of attributes by removing them from your model.  You can safely re
 - mailer
 - subject
 - content
+- data
 
 ### Configuration
 

--- a/app/models/ahoy/message.rb
+++ b/app/models/ahoy/message.rb
@@ -3,5 +3,7 @@ module Ahoy
     self.table_name = "ahoy_messages"
 
     belongs_to :user, polymorphic: true
+
+    serialize :data, Hash
   end
 end

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -21,6 +21,7 @@ module AhoyEmail
         ahoy_message.mailer = options[:mailer] if ahoy_message.respond_to?(:mailer=)
         ahoy_message.subject = message.subject if ahoy_message.respond_to?(:subject=)
         ahoy_message.content = message.to_s if ahoy_message.respond_to?(:content=)
+        ahoy_message.data = options[:data].presence if ahoy_message.respond_to?(:data=)
 
         ahoy_message.save
         message["Ahoy-Message-Id"] = ahoy_message.id

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -24,7 +24,7 @@ module AhoyEmail
         ahoy_message.data = options[:data].presence if ahoy_message.respond_to?(:data=)
 
         ahoy_message.save
-        message["Ahoy-Message-Id"] = ahoy_message.id
+        message["Ahoy-Message-Id"] = ahoy_message.id.to_s
       end
     rescue => e
       report_error(e)

--- a/lib/generators/ahoy_email/templates/install.rb
+++ b/lib/generators/ahoy_email/templates/install.rb
@@ -13,6 +13,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration
       t.string :mailer
       t.text :subject
       t.text :content
+      t.text :data
 
       # timestamps
       t.timestamp :sent_at


### PR DESCRIPTION
Solves the same problem as #8, but my approach seems more idiomatic for this lib.

It's a little tough developing without tests -- @ankane, is there any reason there's no simple test suite for this gem? I'm assuming it's just because of time & bandwidth constraints, something I totally understand :)