### PR TITLE
Send ahoy_message.id as a string

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -23,7 +23,7 @@ module AhoyEmail
         ahoy_message.content = message.to_s if ahoy_message.respond_to?(:content=)
 
         ahoy_message.save
-        message["Ahoy-Message-Id"] = ahoy_message.id
+        message["Ahoy-Message-Id"] = ahoy_message.id.to_s
       end
     rescue => e
       report_error(e)


### PR DESCRIPTION
Hi,

I'm running a Rails 3.1.0 application and I try to use ahoy_email, but after send an email I had an error like:

```
undefined method `index' for 1:Fixnum
```

It was occurring in `https://github.com/mikel/mail/blob/2.4.4/lib/mail/encodings.rb#L117` because processor was sending the id as a Fixnum, converting to String, everything works.
