### PR TITLE
Process only <a> tags with href attribute in AhoyEmail::Processor

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -90,7 +90,7 @@ module AhoyEmail
         body = (message.html_part || message).body
 
         doc = Nokogiri::HTML(body.raw_source)
-        doc.css("a").each do |link|
+        doc.css("a[href]").each do |link|
           # utm params first
           if options[:utm_params] and !skip_attribute?(link, "utm-params")
             uri = Addressable::URI.parse(link["href"])


### PR DESCRIPTION
If the body of an email contains an `<a>` tag without a href attribute, we get a NoMethodError in the `AhoyEmail::Processor#track_links` method on line 96 in lib/ahoy_email/processor.rb. `link["href"]` returns `nil` in this case. `Addressable::URI.parse(nil)` then throws a NoMethodError because it expects a String.

This method is only for rewriting the href attributes, so all `<a>` tags without this attribute can be skipped.
