### PR TITLE
Selective content logging

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -20,7 +20,19 @@ module AhoyEmail
 
         ahoy_message.mailer = options[:mailer] if ahoy_message.respond_to?(:mailer=)
         ahoy_message.subject = message.subject if ahoy_message.respond_to?(:subject=)
-        ahoy_message.content = message.to_s if ahoy_message.respond_to?(:content=)
+        
+        if ahoy_message.respond_to?(:content=)
+          ahoy_message.content = message.header.encoded
+          ahoy_message.content << "\r\n"
+          if message.html_part
+            ahoy_message.content << message.html_part.body.encoded
+          elsif message.multipart?
+            ahoy_message.content << message.text_part ? message.text_part.body.encoded : nil
+          else
+            ahoy_message.content << message.body.encoded
+          end
+        end
+
 
         ahoy_message.save
         message["Ahoy-Message-Id"] = ahoy_message.id.to_s


### PR DESCRIPTION
Only track the html or text part of a message, not the complete base64 encoded message and all attachments
