### PR TITLE
Allow for custom domain option

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ Or by default
 AhoyEmail.track message: false
 ```
 
+Customize host / domain
+
+```ruby
+track url_options: { host: 'mydomain.com' }
+```
+
 Use a different model
 
 ```ruby

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -22,7 +22,8 @@ module AhoyEmail
     utm_content: nil,
     utm_campaign: proc {|message, mailer| mailer.action_name },
     user: proc{|message, mailer| (message.to.size == 1 ? User.where(email: message.to.first).first : nil) rescue nil },
-    mailer: proc{|message, mailer| "#{mailer.class.name}##{mailer.action_name}" }
+    mailer: proc{|message, mailer| "#{mailer.class.name}##{mailer.action_name}" },
+    url_options: {}
   }
 
   self.subscribers = []

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -138,8 +138,11 @@ module AhoyEmail
       end
     end
 
-    def url_for(options)
-      AhoyEmail::Engine.routes.url_helpers.url_for((ActionMailer::Base.default_url_options || {}).merge(options))
+    def url_for(opt)
+      opt = (ActionMailer::Base.default_url_options || {})
+          .merge(options[:url_options])
+          .merge(opt)
+      AhoyEmail::Engine.routes.url_helpers.url_for(opt)
     end
 
     # not a fan of quiet errors


### PR DESCRIPTION
We have a rails app that runs sites for multiple domains, so we needed to be able to customize the domain for each mailer (we don't set a `default_url_host` on ActionMailer).
