### PR TITLE
Run .to_s on url before checking the url signature rescuing nil error

### DIFF
--- a/app/controllers/ahoy/messages_controller.rb
+++ b/app/controllers/ahoy/messages_controller.rb
@@ -17,7 +17,7 @@ module Ahoy
         @message.opened_at ||= @message.clicked_at
         @message.save!
       end
-      url = params[:url]
+      url = params[:url].to_s
       signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), AhoyEmail.secret_token, url)
       publish :click, url: params[:url]
       if secure_compare(params[:signature], signature)


### PR DESCRIPTION
If someone copies a url from an email incompletely and the ```url``` param isn't present, trying to run line 21 with a nil ```url``` raises an exception.