### PR TITLE
Add valid alt attribute to open.gif tracking image

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -80,7 +80,7 @@ module AhoyEmail
             id: ahoy_message.token,
             format: "gif"
           )
-        pixel = ActionController::Base.helpers.image_tag(url, size: "1x1", alt: nil)
+        pixel = ActionController::Base.helpers.image_tag(url, size: "1x1", alt: "o")
 
         # try to add before body tag
         if raw_source.match(regex)


### PR DESCRIPTION
Hello,

when sending an email with a tracking link, SpamAssassin complains that the open.gif image tag does not have an alt attribute.
This adds a single-letter "0" alt attribute to avoid this issue.