### PR TITLE
Custom Parameters on Ahoy Message

### DIFF
--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -39,6 +39,14 @@ module AhoyEmail
   def self.message_model
     @message_model || Ahoy::Message
   end
+
+  class << self
+    attr_writer :custom_parameters
+  end
+
+  def self.custom_parameters
+    @custom_parameters || []
+  end
 end
 
 ActionMailer::Base.send :include, AhoyEmail::Mailer

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -28,6 +28,10 @@ module AhoyEmail
           ahoy_message.send("#{k}=", options[k.to_sym]) if ahoy_message.respond_to?("#{k}=")
         end
 
+        AhoyEmail.custom_parameters.each do |p|
+          ahoy_message.send("#{p}=", options[p]) if ahoy_message.respond_to?("#{p}=")
+        end
+
         ahoy_message.save
         message["Ahoy-Message-Id"] = ahoy_message.id.to_s
       end


### PR DESCRIPTION
This PR fixes issue #19 

To use:

Add a migration for the AhoyMessages table
``` rails g migration AddCampaignIdToAhoyMessages campaign_id:integer source_id:integer ```

Specify the custom parameters in an initializer (such as ahoy_messages.rb)
```AhoyEmail.custom_parameters = [:campaign_id, :source_id]```

Call Track with your new parameter:
```
def welcome_email(user, campaign, source)
    # ...
    track user: user, campaign_id: campaign.id, source_id: source.id
    mail to: user.email
  end
```

Now, you can add a has_many to your campaign model and your source model:
```
class Campaign
 has_many :messages, class_name: "Ahoy::Message"
end

class Source
 has_many :messages, class_name: "Ahoy::Message"
end
```