### PR TITLE
Support manually-mounted AhoyEmail engine

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  next if has_named_route?('ahoy_email_engine')
   mount AhoyEmail::Engine => "/ahoy"
 end
 


### PR DESCRIPTION
Our app uses a catch-all route as its last entry in `routes.rb`, rendering the automatically-added route unreachable.

To allow for explicit mounting of the `AhoyEmail::Engine`, I added a check to skip automatic mounting in case it already has been mounted.