### PR TITLE
tweak "Extra attributes" section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,17 @@ Use `track utm_params: false` to skip tagging, or skip specific links with:
 
 ### Extra Attributes
 
-Create a migration to add extra attributes to the `ahoy_messages` table and use:
+Create a migration to add extra attributes to the `ahoy_messages` table, for example:
+
+```ruby
+class AddCampaignIdToAhoyMessages < ActiveRecord::Migration
+  def change
+    add_column :ahoy_messages, :campaign_id, :integer
+  end
+end
+```
+
+Then use:
 
 ```ruby
 track extra: {campaign_id: 1}


### PR DESCRIPTION
Originally, I thought that there was supposed to be an `extra` column that gets serialized. This should clear that up :smile: