### PR TITLE
Avoid duplicate tracking

### DIFF
--- a/lib/ahoy_email/mailer.rb
+++ b/lib/ahoy_email/mailer.rb
@@ -21,6 +21,9 @@ module AhoyEmail
     end
 
     def mail_with_ahoy(headers = {}, &block)
+      # this mimics what original method does
+      return message if @_mail_was_called && headers.blank? && !block
+
       message = mail_without_ahoy(headers, &block)
       AhoyEmail::Processor.new(message, self).process
       message


### PR DESCRIPTION
In [Rails's official guide](http://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-callbacks), there's an example:

```ruby
class UserMailer < ApplicationMailer
  after_action :prevent_delivery_to_guests
 
  # skip

  private
 
    def prevent_delivery_to_guests
      if @user && @user.guest?
        mail.perform_deliveries = false
      end
    end
end
```

This will cause `ahoy_email` to create duplicate instances of `Ahoy::Message`.