### PR TITLE
Aovid mail bug to break ahoy_email

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -15,7 +15,7 @@ module AhoyEmail
         if options[:message] && (!options[:only] || options[:only].include?(action_name)) && !options[:except].to_a.include?(action_name)
           @ahoy_message = AhoyEmail.message_model.new
           ahoy_message.token = generate_token
-          ahoy_message.to = message.to.join(", ") if ahoy_message.respond_to?(:to=)
+          ahoy_message.to = Array(message.to).join(", ") if ahoy_message.respond_to?(:to=)
           ahoy_message.user = options[:user]
 
           track_open if options[:open]


### PR DESCRIPTION
After deploying safely #38, we observed an exception in production:

```
bundler/gems/ahoy_email-4ce990bb3732/lib/ahoy_email/processor.rb:18:in `block in process': undefined method `join' for #<String:0x0000000c164fc0> (NoMethodError)
    from gems/safely_block-0.1.0/lib/safely_block.rb:27:in `safely'
    from bundler/gems/ahoy_email-4ce990bb3732/lib/ahoy_email/processor.rb:13:in `process'
    from bundler/gems/ahoy_email-4ce990bb3732/lib/ahoy_email/mailer.rb:25:in `mail_with_ahoy'
    from gems/roadie-rails-1.1.0/lib/roadie/rails/mailer.rb:5:in `roadie_mail'
    from app/mailers/notification_mailer.rb:22:in `block in new_recipe_published'
    from gems/safely_block-0.1.0/lib/safely_block.rb:27:in `safely'
    from app/mailers/notification_mailer.rb:17:in `new_recipe_published'
    from gems/actionpack-4.2.5/lib/abstract_controller/base.rb:198:in `process_action'
    from gems/actionpack-4.2.5/lib/abstract_controller/callbacks.rb:20:in `block in process_action'
    from gems/activesupport-4.2.5/lib/active_support/callbacks.rb:117:in `call'
    from gems/activesupport-4.2.5/lib/active_support/callbacks.rb:117:in `call'
    from gems/activesupport-4.2.5/lib/active_support/callbacks.rb:555:in `block (2 levels) in compile'
    from gems/activesupport-4.2.5/lib/active_support/callbacks.rb:505:in `call'
    from gems/activesupport-4.2.5/lib/active_support/callbacks.rb:505:in `call'
    from gems/activesupport-4.2.5/lib/active_support/callbacks.rb:92:in `__run_callbacks__'
    from gems/activesupport-4.2.5/lib/active_support/callbacks.rb:778:in `_run_process_action_callbacks'
    from gems/activesupport-4.2.5/lib/active_support/callbacks.rb:81:in `run_callbacks'
    from gems/actionpack-4.2.5/lib/abstract_controller/callbacks.rb:19:in `process_action'
    from gems/actionpack-4.2.5/lib/abstract_controller/base.rb:137:in `process'
    from gems/actionview-4.2.5/lib/action_view/rendering.rb:30:in `process'
    from gems/actionmailer-4.2.5/lib/action_mailer/base.rb:596:in `block in process'
    from gems/activesupport-4.2.5/lib/active_support/notifications.rb:164:in `block in instrument'
    from gems/activesupport-4.2.5/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    from gems/activesupport-4.2.5/lib/active_support/notifications.rb:164:in `instrument'
    from gems/actionmailer-4.2.5/lib/action_mailer/base.rb:593:in `process'
    from gems/actionmailer-4.2.5/lib/action_mailer/base.rb:584:in `initialize'
    from gems/actionmailer-4.2.5/lib/action_mailer/message_delivery.rb:25:in `new'
    from gems/actionmailer-4.2.5/lib/action_mailer/message_delivery.rb:25:in `__getobj__'
    from gems/actionmailer-4.2.5/lib/action_mailer/message_delivery.rb:34:in `message'
    from gems/actionmailer-4.2.5/lib/action_mailer/message_delivery.rb:85:in `deliver_now'
    from gems/actionmailer-4.2.5/lib/action_mailer/message_delivery.rb:105:in `deliver'
    from app/workers/new_recipe_notification_worker.rb:5:in `perform'
    from gems/sidekiq-4.0.1/lib/sidekiq/processor.rb:150:in `execute_job'
    from gems/sidekiq-4.0.1/lib/sidekiq/processor.rb:132:in `block (2 levels) in process'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:127:in `block in invoke'
    from gems/librato-rack-0.5.0/lib/librato/collector/aggregator.rb:80:in `measure'
    from /usr/local/lib/ruby/2.2.0/forwardable.rb:183:in `timing'
    from /usr/local/lib/ruby/2.2.0/forwardable.rb:183:in `timing'
    from /usr/local/lib/ruby/2.2.0/forwardable.rb:286:in `timing'
    from config/initializers/sidekiq.rb:16:in `time'
    from gems/sidekiq-pro-3.0.0/lib/sidekiq/middleware/server/statsd.rb:30:in `call'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
    from gems/sidekiq-pro-3.0.0/lib/sidekiq/pro/expiry.rb:29:in `call'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
    from gems/sidekiq-pro-3.0.0/lib/sidekiq/batch/middleware.rb:26:in `call'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
    from gems/sidetiq-0.6.3/lib/sidetiq/middleware/history.rb:8:in `call'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/server/active_record.rb:6:in `call'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/server/retry_jobs.rb:74:in `call'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/server/logging.rb:11:in `block in call'
    from gems/sidekiq-4.0.1/lib/sidekiq/logging.rb:30:in `with_context'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/server/logging.rb:7:in `call'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:129:in `block in invoke'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:132:in `call'
    from gems/sidekiq-4.0.1/lib/sidekiq/middleware/chain.rb:132:in `invoke'
    from gems/sidekiq-4.0.1/lib/sidekiq/processor.rb:127:in `block in process'
    from gems/sidekiq-4.0.1/lib/sidekiq/processor.rb:166:in `stats'
    from gems/sidekiq-4.0.1/lib/sidekiq/processor.rb:126:in `process'
    from gems/sidekiq-4.0.1/lib/sidekiq/processor.rb:79:in `process_one'
    from gems/sidekiq-4.0.1/lib/sidekiq/processor.rb:67:in `run'
    from gems/sidekiq-4.0.1/lib/sidekiq/util.rb:16:in `watchdog'
    from gems/sidekiq-4.0.1/lib/sidekiq/util.rb:24:in `block in safe_thread'
```

AFAIK, mail should always returns an array no matter we only set a mail or multiple mails. 