### PR TITLE
Re-enable utm tags on unsubscribe links

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ Use `track utm_params: false` to skip tagging, or skip specific links with:
 <a data-skip-utm-params="true" href="...">Break it down</a>
 ```
 
+By default, links with an href matching "unsubscribe" will be ignored. To re-enable tracking on unsubscribe links, use: track unsubscribe_links: true
+
+```ruby
+track unsubscribe_links: true
+```
+
 ### Extra Attributes
 
 Create a migration to add extra attributes to the `ahoy_messages` table, for example:

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -139,7 +139,7 @@ module AhoyEmail
         # remove it
         link.remove_attribute(attribute)
         true
-      elsif link["href"].to_s =~ /unsubscribe/i
+      elsif link["href"].to_s =~ /unsubscribe/i && !options[:unsubscribe_links]
         # try to avoid unsubscribe links
         true
       else


### PR DESCRIPTION
skip_attribute? should not automatically skip unsubscribe links. It is helpful to be able to track which emails result in unsubscribes using utm tags.  Besides, the gem api provides the ability to manually skip utm tags on unsubscribe links through the track utm_params data attribute.
