### PR TITLE
Track open and click counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ AhoyEmail.message_model = UserMessage
 
 ## Upgrading
 
+## 3.1
+
+Optionally, track open and click counts by incrementing open_count and click_count on your message model.
+
 ### 0.2.3
 
 Optionally, you can store UTM parameters by adding `utm_source`, `utm_medium`, and `utm_campaign` columns to your message model.

--- a/lib/ahoy_email/version.rb
+++ b/lib/ahoy_email/version.rb
@@ -1,3 +1,3 @@
 module AhoyEmail
-  VERSION = "0.3.0"
+  VERSION = "0.3.1"
 end

--- a/lib/generators/ahoy_email/templates/install.rb
+++ b/lib/generators/ahoy_email/templates/install.rb
@@ -20,6 +20,10 @@ class <%= migration_class_name %> < ActiveRecord::Migration
       # t.string :utm_content
       # t.string :utm_campaign
 
+      # optional
+      # t.integer :open_count, default: 0
+      # t.integer :click_count, default: 0
+
       # timestamps
       t.timestamp :sent_at
       t.timestamp :opened_at


### PR DESCRIPTION
Ability to optionally track open_count and click_count. Version bump to 3.1. Updated Readme.