### PR TITLE
Call secure compare with empty string if signature is nil

### DIFF
--- a/app/controllers/ahoy/messages_controller.rb
+++ b/app/controllers/ahoy/messages_controller.rb
@@ -20,7 +20,7 @@ module Ahoy
       url = params[:url].to_s
       signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), AhoyEmail.secret_token, url)
       publish :click, url: params[:url]
-      if secure_compare(params[:signature], signature)
+      if secure_compare(params[:signature].to_s, signature)
         redirect_to url
       else
         redirect_to main_app.root_url


### PR DESCRIPTION
Calling bytesize with a nil signature caused the method to throw an exception rather than return false.