### PR TITLE
Use before_action if available

### DIFF
--- a/app/controllers/ahoy/messages_controller.rb
+++ b/app/controllers/ahoy/messages_controller.rb
@@ -1,6 +1,10 @@
 module Ahoy
   class MessagesController < ActionController::Base
-    before_filter :set_message
+    if respond_to? :before_action
+      before_action :set_message
+    else
+      before_filter :set_message
+    end
 
     def open
       if @message && !@message.opened_at


### PR DESCRIPTION
With Rails 5 officially out, `before_filter` is deprecated, giving this message each time `Ahoy::MessagesController` is spun up:

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. Use before_action instead.
```

This uses `before_action` when it's available.