### PR TITLE
improve redirect

### DIFF
--- a/app/controllers/ahoy/messages_controller.rb
+++ b/app/controllers/ahoy/messages_controller.rb
@@ -27,7 +27,7 @@ module Ahoy
       if secure_compare(params[:signature].to_s, signature)
         redirect_to url
       else
-        redirect_to main_app.root_url
+        redirect_to send(AhoyEmail.router_name).send(AhoyEmail.unknow_url_redirect)
       end
     end
 

--- a/app/controllers/ahoy/messages_controller.rb
+++ b/app/controllers/ahoy/messages_controller.rb
@@ -27,7 +27,7 @@ module Ahoy
       if secure_compare(params[:signature].to_s, signature)
         redirect_to url
       else
-        redirect_to send(AhoyEmail.router_name).send(AhoyEmail.unknow_url_redirect)
+        redirect_to AhoyEmail.invalid_redirect_url
       end
     end
 

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -11,7 +11,7 @@ require "ahoy_email/mailer"
 require "ahoy_email/engine"
 
 module AhoyEmail
-  mattr_accessor :secret_token, :options, :subscribers, :belongs_to
+  mattr_accessor :secret_token, :options, :subscribers, :belongs_to, :unknow_url_redirect, :router_name
 
   self.options = {
     message: true,
@@ -27,6 +27,10 @@ module AhoyEmail
     mailer: proc { |message, mailer| "#{mailer.class.name}##{mailer.action_name}" },
     url_options: {}
   }
+
+  self.unknow_url_redirect = :root_path
+
+  self.router_name = :main_app
 
   self.subscribers = []
 

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -11,7 +11,7 @@ require "ahoy_email/mailer"
 require "ahoy_email/engine"
 
 module AhoyEmail
-  mattr_accessor :secret_token, :options, :subscribers, :belongs_to, :unknow_url_redirect, :router_name
+  mattr_accessor :secret_token, :options, :subscribers, :belongs_to, :invalid_redirect_url
 
   self.options = {
     message: true,
@@ -28,9 +28,7 @@ module AhoyEmail
     url_options: {}
   }
 
-  self.unknow_url_redirect = :root_path
-
-  self.router_name = :main_app
+  self.invalid_redirect_url = '/'
 
   self.subscribers = []
 


### PR DESCRIPTION
Improve redirect for unknown url.
- added ability to override redirect path
- added ability use ahoy_email from rails engine

example

```
AhoyEmail.router_name = :my_engine
AhoyEmail.unknow_url_redirect = :dashboard_url
```
