### PR TITLE
Specify ruby version due to prepend being >= 2.1

### DIFF
--- a/ahoy_email.gemspec
+++ b/ahoy_email.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  spec.required_ruby_version = '>= 2.1.0'
+
   spec.add_runtime_dependency "rails"
   spec.add_runtime_dependency "addressable"
   spec.add_runtime_dependency "nokogiri"


### PR DESCRIPTION
This [commit] (https://github.com/ankane/ahoy_email/commit/9416ab989b942cd556d09380f9072c260c2d6551) breaks things before ruby 2.1 since it was a private method before. Wanted to add this so that it's more obvious that it would happen. I've never really written a gem before so I'm not sure if this is actually how to do things but yeah.