### PR TITLE
Handle array params in track_links

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -103,9 +103,10 @@ module AhoyEmail
           next unless trackable?(uri)
           # utm params first
           if options[:utm_params] && !skip_attribute?(link, "utm-params")
-            params = uri.query_values || {}
+            params = uri.query_values(Array) || []
             UTM_PARAMETERS.each do |key|
-              params[key] ||= options[key.to_sym] if options[key.to_sym]
+              next if params.any? { |k, _v| k == key } || !options[key.to_sym]
+              params << [key, options[key.to_sym]]
             end
             uri.query_values = params
             link["href"] = uri.to_s


### PR DESCRIPTION
When a link has a url with array params, e.g. `http://foo.bar/?baz[]=1&baz[]=2`, the first n-1 values get dropped when calling track_links. This allows passing those through.

My apologies for no tests; I tried my best to write some but am not familiar enough with actionmailer/actioncontroller/etc. and how all this is set up to get a call to track_links to run without errors.