### PR TITLE
Fix: add empty `alt` param to the tracking pixel

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -82,7 +82,7 @@ module AhoyEmail
             id: ahoy_message.token,
             format: "gif"
           )
-        pixel = ActionController::Base.helpers.image_tag(url, size: "1x1", alt: nil)
+        pixel = ActionController::Base.helpers.image_tag(url, size: "1x1", alt: "")
 
         # try to add before body tag
         if raw_source.match(regex)


### PR DESCRIPTION
Right now the gem is appending a 1x1 pixel image to the emails, but the `alt` param is initialized with `nil`, thus preventing it to appear in the mail body.
This change should fix it.