### PR TITLE
modified migration template for rails 5.x

### DIFF
--- a/lib/generators/ahoy_email/templates/install.rb
+++ b/lib/generators/ahoy_email/templates/install.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration
+class <%= migration_class_name %> < ActiveRecord::Migration[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]
   def change
     create_table :ahoy_messages do |t|
       t.string :token

--- a/lib/generators/ahoy_email/templates/install.rb
+++ b/lib/generators/ahoy_email/templates/install.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration["#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"]
+class <%= migration_class_name %> < ActiveRecord::Migration[<%= "#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}" %>]
   def change
     create_table :ahoy_messages do |t|
       t.string :token

--- a/lib/generators/ahoy_email/templates/install.rb
+++ b/lib/generators/ahoy_email/templates/install.rb
@@ -1,4 +1,4 @@
-class <%= migration_class_name %> < ActiveRecord::Migration[#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}]
+class <%= migration_class_name %> < ActiveRecord::Migration["#{Rails::VERSION::MAJOR}.#{Rails::VERSION::MINOR}"]
   def change
     create_table :ahoy_messages do |t|
       t.string :token


### PR DESCRIPTION
Rails 5.x onwards, all the migrations are versioned and 5.1 has strict rules to check the same.

ref - http://blog.bigbinary.com/2016/03/01/migrations-are-versioned-in-rails-5.html