### PR TITLE
Allows persistence of only the text part of a message

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Skip tracking of attributes by removing them from your model.  You can safely re
 - mailer
 - subject
 - content
+- content_text
 
 ### Configuration
 

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -21,9 +21,10 @@ module AhoyEmail
           track_open if options[:open]
           track_links if options[:utm_params] || options[:click]
 
-          ahoy_message.mailer = options[:mailer] if ahoy_message.respond_to?(:mailer=)
-          ahoy_message.subject = message.subject if ahoy_message.respond_to?(:subject=)
-          ahoy_message.content = message.to_s if ahoy_message.respond_to?(:content=)
+          ahoy_message.mailer       = options[:mailer] if ahoy_message.respond_to?(:mailer=)
+          ahoy_message.subject      = message.subject if ahoy_message.respond_to?(:subject=)
+          ahoy_message.content      = message.to_s if ahoy_message.respond_to?(:content=)
+          ahoy_message.content_text = message.text_part.to_s if ahoy_message.respond_to?(:content_text=)
 
           UTM_PARAMETERS.each do |k|
             ahoy_message.send("#{k}=", options[k.to_sym]) if ahoy_message.respond_to?("#{k}=")

--- a/lib/generators/ahoy_email/templates/install.rb
+++ b/lib/generators/ahoy_email/templates/install.rb
@@ -12,6 +12,7 @@ class <%= migration_class_name %> < ActiveRecord::Migration<%= migration_version
       t.string :mailer
       t.text :subject
       # t.text :content
+      # t.text :content_text
 
       # optional
       # t.string :utm_source

--- a/test/internal/db/schema.rb
+++ b/test/internal/db/schema.rb
@@ -11,6 +11,7 @@ ActiveRecord::Schema.define do
     t.string :mailer
     t.text :subject
     t.text :content
+    t.text :content_text
 
     # optional
     t.string :utm_source


### PR DESCRIPTION
Useful to save storage space when sending very large multi-part emails
containing inline attachments.