### PR TITLE
If sending to multiple users, attach message to first user (instead of ignoring completely)

### DIFF
--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -23,7 +23,7 @@ module AhoyEmail
     utm_term: nil,
     utm_content: nil,
     utm_campaign: proc { |message, mailer| mailer.action_name },
-    user: proc { |message, mailer| (message.to.size == 1 ? User.where(email: message.to.first).first : nil) rescue nil },
+    user: proc { |message, mailer| User.where(email: message.to.first).first },
     mailer: proc { |message, mailer| "#{mailer.class.name}##{mailer.action_name}" },
     url_options: {}
   }


### PR DESCRIPTION
I'm not sure why this library ignores emails completely if they're sent to multiple recipients. Maybe in an ideal word, messages would have a many-to-many relationship with User's so that multiple users can be attached to one message. But that's a pretty significant departure from the current implementation.

The README clearly states that "By default, Ahoy tries User.where(email: message.to.first).first to find the user", so I think the expected behavior is that the message would attach to ONE user of the multiple recipients.