### PR TITLE
global disable

### DIFF
--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -16,6 +16,7 @@ module AhoyEmail
     message: true,
     open: true,
     click: true,
+    enabled: true,
     utm_params: true,
     utm_source: proc { |message, mailer| mailer.mailer_name },
     utm_medium: "email",
@@ -41,6 +42,14 @@ module AhoyEmail
 
   def self.message_model
     (defined?(@message_model) && @message_model) || ::Ahoy::Message
+  end
+
+  def self.disable!
+    self.options[:enabled] = false
+  end
+
+  def self.enabled?
+    !!self.options[:enabled]
   end
 end
 

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -48,6 +48,10 @@ module AhoyEmail
     self.options[:enabled] = false
   end
 
+  def self.enable!
+    self.options[:enabled] = true
+  end
+
   def self.enabled?
     !!self.options[:enabled]
   end

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -12,7 +12,7 @@ module AhoyEmail
     def process
       Safely.safely do
         action_name = mailer.action_name.to_sym
-        if options[:message] && (!options[:only] || options[:only].include?(action_name)) && !options[:except].to_a.include?(action_name)
+        if AhoyEmail.enabled? && options[:message] && (!options[:only] || options[:only].include?(action_name)) && !options[:except].to_a.include?(action_name)
           @ahoy_message = AhoyEmail.message_model.new
           ahoy_message.token = generate_token
           ahoy_message.to = Array(message.to).join(", ") if ahoy_message.respond_to?(:to=)
@@ -39,11 +39,11 @@ module AhoyEmail
 
     def track_send
       Safely.safely do
-        if (message_id = message["Ahoy-Message-Id"]) && message.perform_deliveries
+        if AhoyEmail.enabled? && (message_id = message["Ahoy-Message-Id"]) && message.perform_deliveries
           ahoy_message = AhoyEmail.message_model.where(id: message_id.to_s).first
           if ahoy_message
             ahoy_message.sent_at = Time.now
-            ahoy_message.save
+            ahoy_message.save!
           end
           message["Ahoy-Message-Id"] = nil
         end

--- a/test/mailer_test.rb
+++ b/test/mailer_test.rb
@@ -25,6 +25,10 @@ class UserMailer < ActionMailer::Base
     html_message('<a href="http://example.org?baz[]=1&amp;baz[]=2">Hi<a>')
   end
 
+  def welcome6
+    mail to: "test@example.org", subject: "Hello", body: "World"
+  end
+
   private
 
     def prevent_delivery_to_guests
@@ -72,6 +76,13 @@ class MailerTest < Minitest::Test
     message = UserMailer.welcome5
     body = message.body.to_s
     assert_match "baz%5B%5D=1&amp;baz%5B%5D=2", body
+  end
+
+  def test_global_disable
+    AhoyEmail.disable!
+    message = UserMailer.welcome6
+    message.respond_to?(:deliver_now) ? message.deliver_now : message.deliver
+    assert_equal 0, Ahoy::Message.count
   end
 
   private

--- a/test/mailer_test.rb
+++ b/test/mailer_test.rb
@@ -45,6 +45,7 @@ end
 
 class MailerTest < Minitest::Test
   def setup
+    AhoyEmail.enable!
     Ahoy::Message.delete_all
   end
 


### PR DESCRIPTION
This PR adds `disable!` global option.

Assuming we use `track user: user` per email action, using `AhoyEmail.track message: false` is ineffective.
Scenario: using gem such as `email_preview` would create `Ahoy::Message` records and update them when opened.