### PR TITLE
Allow for custom processor

### DIFF
--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -36,11 +36,15 @@ module AhoyEmail
   end
 
   class << self
-    attr_writer :message_model
+    attr_writer :message_model, :processor
   end
 
   def self.message_model
     (defined?(@message_model) && @message_model) || ::Ahoy::Message
+  end
+      
+  def self.processor
+    (defined?(@processor) && @processor) || ::AhoyEmail::Processor
   end
 end
 

--- a/lib/ahoy_email/mailer.rb
+++ b/lib/ahoy_email/mailer.rb
@@ -26,7 +26,7 @@ module AhoyEmail
         return message if @_mail_was_called && headers.blank? && !block
 
         message = super
-        AhoyEmail::Processor.new(message, self).process
+        AhoyEmail.processor.new(message, self).process
         message
       end
     end

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -54,8 +54,8 @@ module AhoyEmail
 
     def options
       @options ||= begin
-        options = AhoyEmail.options.merge(mailer.class.ahoy_options)
-        if mailer.ahoy_options
+        options = AhoyEmail.options.merge(mailer.class.try(:ahoy_options) || {})
+        if mailer.try(:ahoy_options)
           options = options.except(:only, :except).merge(mailer.ahoy_options)
         end
         options.each do |k, v|
@@ -96,7 +96,6 @@ module AhoyEmail
     def track_links
       if html_part?
         body = (message.html_part || message).body
-
         doc = Nokogiri::HTML(body.raw_source)
         doc.css("a[href]").each do |link|
           uri = parse_uri(link["href"])

--- a/lib/ahoy_email/version.rb
+++ b/lib/ahoy_email/version.rb
@@ -1,3 +1,3 @@
 module AhoyEmail
-  VERSION = "0.5.0"
+  VERSION = "0.5.1"
 end


### PR DESCRIPTION
You should allow for a custom processor class setting similar to the custom message model setting. This class can inherit from yours and override the sections that are necessary. In my case, I wanted to define a custom `process` method that retrieves a previously created message. I create my messages ahead of time and also have a different schema. Here is an example:

```
class MailingProcessor < AhoyEmail::Processor

  def process
    Safely.safely do
      action_name = mailer.action_name.to_sym

      if options[:message] && (!options[:only] || options[:only].include?(action_name)) && !options[:except].to_a.include?(action_name)
        @ahoy_message = AhoyEmail.message_model.where(message_id: message["Message-ID"]).first
        ahoy_message.token = generate_token

        track_open if options[:open]
        track_links if options[:utm_params] || options[:click]

        UTM_PARAMETERS.each do |k|
          ahoy_message.send("#{k}=", options[k.to_sym]) if ahoy_message.respond_to?("#{k}=")
        end

        ahoy_message.save!
      end
    end
  end
end
```

Let me know if you have any questions.