### PR TITLE
Post Process Inline with Roadie

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.gem
 *.rbc
+.idea
 .bundle
 .config
 .yardoc

--- a/ahoy_email.gemspec
+++ b/ahoy_email.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "addressable", ">= 2.3.2"
   spec.add_dependency "nokogiri"
   spec.add_dependency "safely_block", ">= 0.1.1"
+  spec.add_dependency "roadie",       "~> 3.4"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -4,6 +4,7 @@ require "addressable/uri"
 require "nokogiri"
 require "openssl"
 require "safely/core"
+require "roadie"
 
 # modules
 require "ahoy_email/processor"

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -111,8 +111,8 @@ module AhoyEmail
           end
         end
 
-        # hacky
-        body.raw_source.sub!(body.raw_source, doc.to_s)
+        # hacky (even more with Roadie ;)
+        body.raw_source.sub!(body.raw_source, Roadie::Document.new(doc.to_s).transform)
       end
     end
 


### PR DESCRIPTION
This change ensures emails are following inline css guidelines in order to prevent layout style broke in clients like gmail.

For some reason, after the Nokogiri HTML reasembly, sometimes HTML loses some styles. This loss pass unobserved in many cases, but, specifically in gmail, it becomes huge. 

For this reason I added Roadie gem and used the transform method to reprocess the html and ensure it's correct.