### PR TITLE
Handle the case of a mailer method that ends up not sending any mail.

### DIFF
--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -29,7 +29,7 @@ module AhoyEmail
     utm_term: nil,
     utm_content: nil,
     utm_campaign: -> { action_name },
-    user: -> { @user || (respond_to?(:params) && params && params[:user]) || (message.to.size == 1 ? (User.find_by(email: message.to.first) rescue nil) : nil) },
+    user: -> { @user || (respond_to?(:params) && params && params[:user]) || (message.to&.size == 1 ? (User.find_by(email: message.to.first) rescue nil) : nil) },
     mailer: -> { "#{self.class.name}##{action_name}" },
     url_options: {},
     extra: {},

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -29,7 +29,7 @@ module AhoyEmail
     utm_term: nil,
     utm_content: nil,
     utm_campaign: -> { action_name },
-    user: -> { @user || (respond_to?(:params) && params && params[:user]) || (message.to&.size == 1 ? (User.find_by(email: message.to.first) rescue nil) : nil) },
+    user: -> { @user || (respond_to?(:params) && params && params[:user]) || (message.to.try(:size) == 1 ? (User.find_by(email: message.to.first) rescue nil) : nil) },
     mailer: -> { "#{self.class.name}##{action_name}" },
     url_options: {},
     extra: {},

--- a/test/internal/app/mailers/unmailed_mailer.rb
+++ b/test/internal/app/mailers/unmailed_mailer.rb
@@ -1,0 +1,3 @@
+class UnmailedMailer < ActionMailer::Base
+  def hello; end
+end

--- a/test/unmailed_test.rb
+++ b/test/unmailed_test.rb
@@ -1,0 +1,8 @@
+require_relative "test_helper"
+
+class UnmailedTest < Minitest::Test
+  def test_unmailed
+    UnmailedMailer.hello.deliver_now
+    assert_nil ahoy_message
+  end
+end


### PR DESCRIPTION
I'm upgrading from 0.5.2 to 1.0.2, and we're suddenly seeing errors in mailer tests in cases where the `to` list is whittled down to nothing, so we don't send the mail (calling `mail` with a blank `to` throws STMP errors), and nil is returned from the mailer method

I don't think the line that sets `:user` changed between the two versions, so I'm not sure if our case is supposed to even make it that far, but the fix was one character, assuming targetted Ruby versions all have the safe navigation operator.