### PR TITLE
RFC FEA/Open Tracking with Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.0.3 [unreleased]
 
 - Fixed custom message model
+- Changed GA tracking to pageview instead of event
+- Reduce DB hits on open, click operations
+- Rubocop fixes
 
 ## 1.0.2
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,13 @@ Skip specific links with:
 
 #### Setup
 
-Additional setup is required to track opens and clicks.
+You can track opens with Google Analytics without the additional the additional configuration below.   
+
+Add a GA tracking code to your `ahoy_email.rb` initializer:
+
+```ruby
+AhoyEmail.default_options[:google_analytics_code] = 'UA-something-here-N'
+```
 
 Create a migration with:
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Skip specific links with:
 
 #### Setup
 
-You can track opens with Google Analytics without the additional the additional configuration below.   
+You can track opens with Google Analytics without the need for web endpoints and local storage with the additional configuration below.   
 
 Add a GA tracking code to your `ahoy_email.rb` initializer:
 

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -33,7 +33,8 @@ module AhoyEmail
     mailer: -> { "#{self.class.name}##{action_name}" },
     url_options: {},
     extra: {},
-    unsubscribe_links: false
+    unsubscribe_links: false,
+    google_analytics_code: nil
   }
 
   self.track_method = lambda do |data|

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -84,7 +84,7 @@ module AhoyEmail
         raw_source = (message.html_part || message).body.raw_source
         regex = /<\/body>/i
 
-        epath = "/email/#{mailer_name}/#{action_name}"
+        epath = "/email/#{mailer.mailer_name}/#{mailer.action_name}"
 
         tracker = {
           v: 1,
@@ -108,7 +108,7 @@ module AhoyEmail
         end
       end
     end
-    
+
     def track_links
       if html_part?
         body = (message.html_part || message).body


### PR DESCRIPTION
This PR enables you to track opens with GA in addition to, or instead of with the integrated open tracking. Opens are shown as page views on your web property /email/{mailer}/{action} by default.