### PR TITLE
Fix incorrect reconstruction of emails with <head> elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3 (unreleased)
+
+- Fixed `utm_params` and `track_clicks` stripping `<head>` tags from messages
+
 ## 2.0.2 (2021-03-14)
 
 - Added support for Mongoid to database subscriber

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -53,7 +53,7 @@ module AhoyEmail
       if html_part?
         part = message.html_part || message
 
-        doc = Nokogiri::HTML::DocumentFragment.parse(part.body.raw_source)
+        doc = Nokogiri::HTML::Document.parse(part.body.raw_source)
         doc.css("a[href]").each do |link|
           uri = parse_uri(link["href"])
           next unless trackable?(uri)

--- a/test/internal/app/mailers/utm_params_mailer.rb
+++ b/test/internal/app/mailers/utm_params_mailer.rb
@@ -23,4 +23,16 @@ class UtmParamsMailer < ApplicationMailer
   def multiple
     mail_html('<a href="https://example.org">Test</a>')
   end
+
+  def head_element
+    mail_html('<html><head><style>a {color: red;}</style></head></html>')
+  end
+
+  def doctype
+    mail_html('<!DOCTYPE html><html></html>')
+  end
+
+  def body_style
+    mail_html('<html><body style="background-color:#ABC123;"></body></html>')
+  end
 end

--- a/test/utm_params_test.rb
+++ b/test/utm_params_test.rb
@@ -34,4 +34,20 @@ class UtmParamsTest < Minitest::Test
     message = UtmParamsMailer.multiple.deliver_now
     assert_body "utm_campaign=second", message
   end
+
+  def test_head_element
+    message = UtmParamsMailer.head_element.deliver_now
+    assert_body '<head>', message
+    assert_body '</head>', message
+  end
+
+  def test_doctype
+    message = UtmParamsMailer.doctype.deliver_now
+    assert_body '<!DOCTYPE html>', message
+  end
+
+  def test_body_style
+    message = UtmParamsMailer.body_style.deliver_now
+    assert_body '<body style="background-color:#ABC123;">', message
+  end
 end


### PR DESCRIPTION
## Changes
- Reverted `AhoyEmail::Processor` to use parse the email body as a `Nokogiri::HTML::Document`

## Context
As of v2.0, the processor uses `Nokogiri::HTML::DocumentFragment` to parse the email body, rather than `Nokogiri::HTML::Document`.

Despite what the semantics of `Mail::Message#body` implies, it actually returns the compete HTML document, including the `<head>`.

It appears that `Nokogiri::HTML::DocumentFragment#parse` strips any invalid nodes, essentially anything that's valid within a `<body>` element. The main impact is that any emails relying on `<style>` elements in the header will render without any CSS styling in Gmail. Additionally, the `style=` attribute on the `<body>` tag gets stripped off.

Parsing a document fragment with `Nokogiri::HTML::Document` doesn't appear to have any negative impacts, it simply adds the required elements to create a valid HTML document. There is a possibility that automatically added doctype may cause some formatting issues, and if that's a concern, I can default the doctype to HTML5.

## Before/After behaviour

### With a full HTML document

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <meta http-equiv="Content-Type" content="text/html charset=UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>Test Title</title>
  <style type="text/css">
    a {color: red;}
  </style>
</head>
<body style="background-color:#ABC123;">
<p>
  <a href="https://example.org/">Test Link</a>
</p>
</body>
</html>
```

Parsing as a `Nokogiri::HTML::DocumentFragment` (current behaviour) mangles the HTML into this:

```html
<body>


  <meta http-equiv="Content-Type" content="text/html charset=UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>Test Title</title>
  <style type="text/css">
    a {color: red;}
  </style>


<p>
  <a href="https://example.org/?utm_source=processor_test_mailer&amp;utm_medium=email&amp;utm_campaign=email">Test Link</a>
</p>


</body>
```

Using `Nokogiri::HTML::Document`, the email correctly is processed into this:

```html
<html lang="en">
<head>
  <meta http-equiv="Content-Type" content="text/html charset=UTF-8">
  <meta name="viewport" content="width=device-width, initial-scale=1">
  <title>Test Title</title>
  <style type="text/css">
    a {color: red;}
  </style>
</head>
<body style="background-color:#ABC123;">
<p>
  <a href="https://example.org/?utm_source=processor_test_mailer&amp;utm_medium=email&amp;utm_campaign=email">Test Link</a>
</p>
</body>
</html>
```

### With a document fragment

```html
<p>
  <a href="https://example.org/">Test Link</a>
</p>
```

Current behaviour (`Nokogiri::HTML::DocumentFragment`):

```html
<p>
  <a href="https://example.org/?utm_source=processor_test_mailer&amp;utm_medium=email&amp;utm_campaign=email">Test Link</a>
</p>
```

Using `Nokogiri::HTML::Document`:

```html
<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
<html><body>
<p>
  <a href="https://example.org/?utm_source=processor_test_mailer&amp;utm_medium=email&amp;utm_campaign=email">Test Link</a>
</p>
</body></html>
```