### PR TITLE
Preserve default_url_options overrides in the mailer class

### DIFF
--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -123,7 +123,7 @@ module AhoyEmail
     end
 
     def url_for(opt)
-      opt = (ActionMailer::Base.default_url_options || {})
+      opt = (mailer.default_url_options || {})
             .merge(options[:url_options])
             .merge(opt)
       AhoyEmail::Engine.routes.url_helpers.url_for(opt)


### PR DESCRIPTION
We override `default_url_options` in our mailers so that we can have dynamic hosts in the mailer's URLs. Roughly something like:
```
class MyMailer < ActionMailer::Base

  def default_url_options
    { host: "#{some_dynamic_subdomain}.example.com" }
  end

end
```

Going directly through `ActionMailer::Base.default_url_options` circumvents that override. This change will preserve it, but also should fall back to `ActionMailer::Base.default_url_options` if no override exists.