### PR TITLE
Added option `AhoyEmail.invalid_redirect_current_url` to redirect to …

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ Ahoy Email 2.0 brings a number of changes. Here are a few to be aware of:
   If you use a custom subscriber, `:message` is no longer included in click events. You can use `:token` to query the message if needed.
 
 - Users are shown a link expired page when signature verification fails instead of being redirected to the homepage when `AhoyEmail.invalid_redirect_url` is not set
+- Users are redirect to the link current url when signature verification fails when `AhoyEmail.invalid_redirect_current_url` is set true
 
 ## History
 

--- a/app/controllers/ahoy/messages_controller.rb
+++ b/app/controllers/ahoy/messages_controller.rb
@@ -40,6 +40,8 @@ module Ahoy
       else
         if AhoyEmail.invalid_redirect_url
           redirect_to AhoyEmail.invalid_redirect_url, **redirect_options
+        elsif AhoyEmail.invalid_redirect_current_url
+          redirect_to url, **redirect_options
         else
           render plain: "Link expired", status: :not_found
         end

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -24,7 +24,7 @@ require "ahoy_email/redis_subscriber"
 require "ahoy_email/engine" if defined?(Rails)
 
 module AhoyEmail
-  mattr_accessor :secret_token, :default_options, :subscribers, :invalid_redirect_url, :track_method, :api, :preserve_callbacks, :save_token
+  mattr_accessor :secret_token, :default_options, :subscribers, :invalid_redirect_url, :invalid_redirect_current_url, :track_method, :api, :preserve_callbacks, :save_token
   mattr_writer :message_model
 
   self.api = false

--- a/test/click_test.rb
+++ b/test/click_test.rb
@@ -46,6 +46,16 @@ class ClickTest < ActionDispatch::IntegrationTest
     end
   end
 
+  def test_invalid_redirect_current_url
+    with_invalid_redirect_current_url(true) do
+      message = ClickMailer.basic.deliver_now
+      assert_body "click", message
+      url = /a href=\"([^"]+)\"/.match(message.body.decoded)[1]
+      get url.sub(/\bs=/, "s=bad")
+      assert_redirected_to "https://example.org"
+    end
+  end
+
   def test_mailto
     message = ClickMailer.mailto.deliver_now
     assert_body '<a href="mailto:hi@example.org">', message
@@ -90,6 +100,12 @@ class ClickTest < ActionDispatch::IntegrationTest
 
   def with_invalid_redirect_url(value)
     AhoyEmail.stub(:invalid_redirect_url, value) do
+      yield
+    end
+  end
+
+  def with_invalid_redirect_current_url(value)
+    AhoyEmail.stub(:invalid_redirect_current_url, value) do
       yield
     end
   end


### PR DESCRIPTION
# Changes
* Added option `AhoyEmail.invalid_redirect_current_url` to redirect to a current link url, for example, useful when using a resource in several isolated subnets

# Context
We actively use the library on our resource, namely Click Analytics.

Our shared data resource operates in two isolated network segments (external and internal).

The problem is that if the user has set up email forwarding from the internal network to the external network, then in the received letter when clicking on the link, then of course he gets a blank screen with the "link expired" error.

In such cases, I would like to go to the working page, even if the signature did not pass verification.
To do this, I propose to add an additional option `AhoyEmail.invalid_redirect_current_url`, which, if added, could enable the above behavior.