### PR TITLE
Allow parsing with HTML5

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,16 @@ Get stats for a campaign
 AhoyEmail.stats("my-campaign")
 ```
 
+## HTML5 Parsing
+
+By default, this gem uses Nokogiri's HTML 4 parser to rewrite href attributes for the `utm_params` and `track_clicks` features. This can cause link tags to be prematurely closed if they were wrapping table elements, because doing so violates the HTML 4 spec.
+
+To use HTML5 parsing instead, set this in an initializer:
+
+```ruby
+AhoyEmail.html5 = true
+```
+
 ## History
 
 View the [changelog](https://github.com/ankane/ahoy_email/blob/master/CHANGELOG.md)

--- a/lib/ahoy_email.rb
+++ b/lib/ahoy_email.rb
@@ -24,7 +24,7 @@ require_relative "ahoy_email/redis_subscriber"
 require_relative "ahoy_email/engine" if defined?(Rails)
 
 module AhoyEmail
-  mattr_accessor :secret_token, :default_options, :subscribers, :invalid_redirect_url, :track_method, :api, :preserve_callbacks, :save_token
+  mattr_accessor :secret_token, :default_options, :subscribers, :invalid_redirect_url, :track_method, :api, :preserve_callbacks, :save_token, :html5
   mattr_writer :message_model
 
   self.api = false
@@ -78,6 +78,8 @@ module AhoyEmail
   end
 
   self.save_token = false
+
+  self.html5 = false
 
   self.subscribers = []
 

--- a/lib/ahoy_email/processor.rb
+++ b/lib/ahoy_email/processor.rb
@@ -53,7 +53,7 @@ module AhoyEmail
       if html_part?
         part = message.html_part || message
 
-        doc = Nokogiri::HTML::Document.parse(part.body.raw_source)
+        doc = parse_message(part.body.raw_source)
         doc.css("a[href]").each do |link|
           uri = parse_uri(link["href"])
           next unless trackable?(uri)
@@ -89,6 +89,14 @@ module AhoyEmail
         # escaping technically required before html5
         # https://stackoverflow.com/questions/3705591/do-i-encode-ampersands-in-a-href
         part.body = doc.to_s
+      end
+    end
+
+    def parse_message(raw_source)
+      if AhoyEmail.html5
+        Nokogiri::HTML5.parse(raw_source)
+      else
+        Nokogiri::HTML::Document.parse(raw_source)
       end
     end
 

--- a/test/internal/app/mailers/utm_params_mailer.rb
+++ b/test/internal/app/mailers/utm_params_mailer.rb
@@ -20,6 +20,10 @@ class UtmParamsMailer < ApplicationMailer
     mail_html('<a href="https://example.org"><img src="image.png"></a>')
   end
 
+  def nested_table
+    mail_html('<a href="https://example.org"><table></table></a>')
+  end
+
   def multiple
     mail_html('<a href="https://example.org">Test</a>')
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -85,6 +85,12 @@ class Minitest::Test
       yield
     end
   end
+
+  def with_html5
+    AhoyEmail.stub(:html5, true) do
+      yield
+    end
+  end
 end
 
 class ActionDispatch::IntegrationTest

--- a/test/utm_params_test.rb
+++ b/test/utm_params_test.rb
@@ -30,6 +30,15 @@ class UtmParamsTest < Minitest::Test
     assert_body '<img src="image.png"></a>', message
   end
 
+  # When nokogiri parses with html5, it allows an <a> tag to wrap a <table> tag
+  def test_nested_table_html5
+    with_html5 do
+      message = UtmParamsMailer.nested_table.deliver_now
+      assert_body "utm_medium=email", message
+      assert_body '<table></table></a>', message
+    end
+  end
+
   # When nokogiri parses with html4, it disallows an <a> tag to wrap a <table> tag,
   # and closes the <a> tag before the <table> tag
   def test_nested_table_html4

--- a/test/utm_params_test.rb
+++ b/test/utm_params_test.rb
@@ -30,6 +30,14 @@ class UtmParamsTest < Minitest::Test
     assert_body '<img src="image.png"></a>', message
   end
 
+  # When nokogiri parses with html4, it disallows an <a> tag to wrap a <table> tag,
+  # and closes the <a> tag before the <table> tag
+  def test_nested_table_html4
+    message = UtmParamsMailer.nested_table.deliver_now
+    assert_body "utm_medium=email", message
+    assert_body '</a><table></table>', message
+  end
+
   def test_multiple
     message = UtmParamsMailer.multiple.deliver_now
     assert_body "utm_campaign=second", message


### PR DESCRIPTION
Fixes https://github.com/ankane/ahoy_email/issues/58
Fixed https://github.com/ankane/ahoy_email/issues/148 (at least I assume that OP was using tables)

Nokogiri is on the path to parsing with HTML5 by default: https://github.com/sparklemotion/nokogiri/issues/2331

But, there are some things they still need to do. For those of us who want to opt-in to HTML5 parsing, I've added an option for it. This will prevent the gem from messing with the structure of the html (specifically, prematurely closing <a> tags that wrapped table elements.

I've made sure to leave the gem completely unchanged for those who do not opt-in.