### PR TITLE
Doc: Change `created_at` to `sent_at` in maintenance example

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ end
 Delete older data with:
 
 ```ruby
-Ahoy::Message.where("created_at < ?", 1.year.ago).in_batches.delete_all
+Ahoy::Message.where("sent_at < ?", 1.year.ago).in_batches.delete_all
 ```
 
 Delete data for a specific user with:


### PR DESCRIPTION
`created_at` does not exist on the `ahoy_messages` table.