### PR TITLE
Fix Rails.application.secrets deprecation warning in Rails 7.1

### DIFF
--- a/lib/ahoy_email/engine.rb
+++ b/lib/ahoy_email/engine.rb
@@ -7,19 +7,22 @@ module AhoyEmail
         tokens = []
         tokens << app.key_generator.generate_key("ahoy_email")
 
-        # TODO remove in 3.0
-        creds =
-          if app.respond_to?(:credentials) && app.credentials.secret_key_base
-            app.credentials
-          elsif app.respond_to?(:secrets)
-            app.secrets
-          else
-            app.config
-          end
+        if app.respond_to?(:secret_key_base) && app.secret_key_base
+          tokens << app.secret_key_base
+        else
+          # TODO remove in 3.0
+          creds =
+            if app.respond_to?(:credentials) && app.credentials.secret_key_base
+              app.credentials
+            elsif app.respond_to?(:secrets)
+              app.secrets
+            else
+              app.config
+            end
 
-        token = creds.respond_to?(:secret_key_base) ? creds.secret_key_base : creds.secret_token
-        token ||= app.secret_key_base # should come first, but need to maintain backward compatibility
-        tokens << token
+          token = creds.respond_to?(:secret_key_base) ? creds.secret_key_base : creds.secret_token
+          tokens << token
+        end
 
         tokens
       end


### PR DESCRIPTION
We receive the following deprecation warning in our Rails 7.1 app because we use an environment variable to set up `secret_key_base`:
```
Failure/Error: require File.expand_path('../config/environment', __dir__)

ActiveSupport::DeprecationException:
  DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from <top (required)> at /Users/***/code/recurrent/api/config/environment.rb:5)
# /Users/***/.rvm/gems/ruby-3.1.5/gems/ahoy_email-2.3.0/lib/ahoy_email/engine.rb:11:in `block in <class:Engine>'
# /Users/***/.rvm/gems/ruby-3.1.5/gems/railties-7.1.3.4/lib/rails/initializable.rb:32:in `instance_exec'
# /Users/***/.rvm/gems/ruby-3.1.5/gems/railties-7.1.3.4/lib/rails/initializable.rb:32:in `run'
# /Users/***/.rvm/gems/ruby-3.1.5/gems/railties-7.1.3.4/lib/rails/initializable.rb:61:in `block in run_initializers'
# /Users/***/.rvm/gems/ruby-3.1.5/gems/railties-7.1.3.4/lib/rails/initializable.rb:60:in `run_initializers'
# /Users/***/.rvm/gems/ruby-3.1.5/gems/railties-7.1.3.4/lib/rails/application.rb:426:in `initialize!'
# ...
```

In this PR I've attempted to address this by first checking if `Rails.application` responds to `secret_key_base` and it contains a truthy value before falling back to other mechanisms.

I don't love the big `if/else` block here, but since all of this is inside of a `begin/end` it prevented me from doing an early return.

I'd love to hear if you think this is a reasonably safe fix to address these deprecation warnings until 3.0 is released. I also looked into adding some tests, but I didn't see many that were already exercising this behavior so wasn't sure if I should add some or not. I'm happy to do so if you like!

Thanks for your consideration!